### PR TITLE
Resolve warnings appearing in the dashboard do to PHP display_error settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /var/www/html \
     && ln -s /var/www/html/conf.d/config.php config.php \
     && ln -s /var/www/html/conf.d/config_override.php config_override.php
 
+#Fix php warnings in dashboards
+RUN cd /var/www/html \
+    sed -i.back s/'<?php/<?php\n\nini_set\(display_errors\,0\)\;\nerror_reporting\(E_ALL\ \^\ E_STRICT\)\;\n\n/g' /var/www/html/modules/Calls/Dashlets/MyCallsDashlet/MyCallsDashlet.php
+
 
 RUN apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN cd /var/www/html \
 
 #Fix php warnings in dashboards
 RUN cd /var/www/html \
-    sed -i.back s/'<?php/<?php\n\nini_set\(display_errors\,0\)\;\nerror_reporting\(E_ALL\ \^\ E_STRICT\)\;\n\n/g' /var/www/html/modules/Calls/Dashlets/MyCallsDashlet/MyCallsDashlet.php
+    && sed -i.back s/'<?php/<?php\n\nini_set\(display_errors\,0\)\;\nerror_reporting\(E_ALL\ \^\ E_STRICT\)\;\n\n/g' /var/www/html/modules/Calls/Dashlets/MyCallsDashlet/MyCallsDashlet.php
 
 
 RUN apt-get clean


### PR DESCRIPTION
After installing version 7.8.2  the main page with the dashboard displays about 20 lines of warnings..  This will fix this issues